### PR TITLE
Curl7 Error Fixed

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -5,10 +5,10 @@ namespace Hemengeliriz\ParamposLaravel;
 class Payment extends BaseType
 {
     public const PROD_BASE_URL = 'https://posws.param.com.tr/turkpos.ws/service_turkpos_prod.asmx?wsdl';
-    public const TEST_BASE_URL = 'https://test-dmz.param.com.tr:4443/turkpos.ws/service_turkpos_test.asmx?wsdl';
+    public const TEST_BASE_URL = 'https://test-dmz.param.com.tr/turkpos.ws/service_turkpos_test.asmx?wsdl';
 
     public const PROD_SAVE_CARD_BASE_URL = 'https://posws.param.com.tr/out.ws/service_ks.asmx?wsdl';
-    public const TEST_SAVE_CARD_BASE_URL = 'https://test-dmz.param.com.tr:4443/out.ws/service_ks.asmx?wsdl';
+    public const TEST_SAVE_CARD_BASE_URL = 'https://test-dmz.param.com.tr/out.ws/service_ks.asmx?wsdl';
 
     protected ?Card $card;
     protected ?PaymentDetail $paymentDetail;


### PR DESCRIPTION
for some servers the guzzle library gives curl 7 error.
This problem can be avoided by using curl directly.